### PR TITLE
Display error summary and fix error when processing files with a single empty line

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+1.1.1
+-----
+
+* Display error summary at the end in case some error happens when fixing files.
+
+* Fix bug when a file contained a single empty line.
+
 1.1.0
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ test_requirements = [
 
 setup(
     name='esss_fix_format',
-    version='1.0.0',
+    version='1.1.1',
     description="ESSS code formatter and checker",
     long_description=readme + '\n\n' + changelog,
     author="Bruno Oliveira",

--- a/tests/test_esss_fix_format.py
+++ b/tests/test_esss_fix_format.py
@@ -143,6 +143,23 @@ def test_fix_commit(input_file, mocker, param, tmpdir):
     ]
 
 
+def test_input_invalid_codec(tmpdir):
+    """Display error summary when we fail to open a file"""
+    filename = tmpdir.join('test.py')
+    filename.write(u'hello world'.encode('UTF-16'), 'wb')
+    output = run([str(filename)], expected_exit=1)
+    output.fnmatch_lines(str(filename) + ': ERROR (Unicode*')
+    output.fnmatch_lines('*== ERRORS ==*')
+    output.fnmatch_lines(str(filename) + ': ERROR (Unicode*')
+
+
+def test_empty_file(tmpdir):
+    """Ensure files with a single empty line do not raise an error"""
+    filename = tmpdir.join('test.py')
+    filename.write(u'\r\n', 'w')
+    run([str(filename)], expected_exit=0)
+
+
 def run(args, expected_exit):
     from _pytest.pytester import LineMatcher
     runner = CliRunner()


### PR DESCRIPTION
Found two problems when running it in *batch* on the `souring` repository.