### PR TITLE
Add explicit list of stdlib modules based on our conda distribution

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+
+1.2.2
+-----
+
+* Workaround for isort bug where some stdlib modules are not recognized as such because of a
+  non-standard Python location.
+
 1.2.1
 -----
 

--- a/esss_fix_format/cli.py
+++ b/esss_fix_format/cli.py
@@ -6,9 +6,36 @@ import sys
 import click
 import subprocess
 
+
+# This is a complete list of all modules in our stdlib which are not already known to isort
+# This is a workaround for https://github.com/timothycrosley/isort/issues/464
+all_stdlib_modules = ["Bastion", "CGIHTTPServer", "DocXMLRPCServer", "HTMLParser", "MimeWriter",
+                      "SimpleHTTPServer", "UserDict", "UserList", "UserString", "aifc",
+                      "antigravity", "ast",
+                      "audiodev", "bdb", "binhex", "cgi", "chunk", "code", "codeop", "colorsys",
+                      "cookielib", "copy_reg",
+                      "dummy_thread", "dummy_threading", "formatter", "fpformat", "ftplib",
+                      "genericpath",
+                      "htmlentitydefs", "htmllib", "httplib", "ihooks", "imghdr", "imputil",
+                      "keyword", "macpath", "macurl2path",
+                      "mailcap", "markupbase", "md5", "mimetools", "mimetypes", "mimify",
+                      "modulefinder", "multifile", "mutex",
+                      "netrc", "new", "nntplib", "ntpath", "nturl2path", "numbers", "opcode",
+                      "os2emxpath", "pickletools", "popen2", "poplib", "posixfile", "posixpath",
+                      "pty",
+                      "py_compile", "quopri", "repr", "rexec", "rfc822", "runpy", "sets", "sgmllib",
+                      "sha", "sndhdr", "sre",
+                      "sre_compile", "sre_constants", "sre_parse", "ssl", "stat", "statvfs",
+                      "stringold",
+                      "stringprep", "sunau", "sunaudio", "symbol", "symtable", "telnetlib", "this",
+                      "toaiff", "token",
+                      "tokenize", "tty", "types", "user", "uu", "wave", "xdrlib", "xmllib"]
+
 ISORT_CONFIG = {
     'line_length': 100,
     'multi_line_output': 4,  # 4-vert-grid
+    # This is a workaround for https://github.com/timothycrosley/isort/issues/464
+    'known_standard_library': all_stdlib_modules,
 }
 
 EXTENSIONS = {'.py', '.cpp', '.c', '.h', '.hpp', '.hxx', '.cxx', '.java', '.js'}

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ test_requirements = [
 
 setup(
     name='esss_fix_format',
-    version='1.2.1',
+    version='1.2.2',
     description="ESSS code formatter and checker",
     long_description=readme + '\n\n' + changelog,
     author="Bruno Oliveira",

--- a/tests/test_esss_fix_format.py
+++ b/tests/test_esss_fix_format.py
@@ -221,6 +221,28 @@ def test_isort_bug_with_comment_headers(tmpdir):
     check_valid_file(filename)
 
 
+def test_missing_builtins(tmpdir):
+    source = textwrap.dedent("""\
+        import thirdparty
+        import os
+        import ftplib
+        import numbers
+    """)
+    filename = tmpdir.join('test.py')
+    filename.write(source)
+    check_invalid_file(filename)
+    fix_invalid_file(filename)
+    check_valid_file(filename)
+    obtained = filename.read()
+    assert obtained == textwrap.dedent("""\
+        import ftplib
+        import numbers
+        import os
+
+        import thirdparty
+    """)
+
+
 def run(args, expected_exit):
     from _pytest.pytester import LineMatcher
     runner = CliRunner()


### PR DESCRIPTION
Related to timothycrosley/isort#464

