### PR TITLE
Add support for CMake files (`*.cmake`, `CMakeLists.txt`)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,11 @@ History
 =======
 
 
+1.4.0
+-----
+
+* Add support for CMake files (`*.cmake`, `CMakeLists.txt`).
+
 1.3.0
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ test_requirements = [
 
 setup(
     name='esss_fix_format',
-    version='1.3.0',
+    version='1.4.0',
     description="ESSS code formatter and checker",
     long_description=readme + '\n\n' + changelog,
     author="Bruno Oliveira",

--- a/tests/test_esss_fix_format.py
+++ b/tests/test_esss_fix_format.py
@@ -140,10 +140,10 @@ def test_unknown_extension(input_file):
     new_filename = py.path.local(os.path.splitext(str(input_file))[0] + '.unknown')
     input_file.move(new_filename)
     output = run(['--check', str(new_filename)], expected_exit=0)
-    output.fnmatch_lines(str(new_filename) + ': Unknown extension')
+    output.fnmatch_lines(str(new_filename) + ': Unknown file type')
 
     output = run([str(new_filename)], expected_exit=0)
-    output.fnmatch_lines(str(new_filename) + ': Unknown extension')
+    output.fnmatch_lines(str(new_filename) + ': Unknown file type')
 
 
 @pytest.mark.parametrize('param', ['-c', '--commit'])


### PR DESCRIPTION
Change to check by glob pattern instead of extensions.
Will also be case-insensitive on Windows.