### PR TITLE
Fix support for filenames in pattern (such as `CMakeLists.txt`), when…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,11 @@ History
 =======
 
 
+1.4.1
+-----
+
+* Fix support for filenames in pattern (such as `CMakeLists.txt`), when in subdirectories.
+
 1.4.0
 -----
 

--- a/esss_fix_format/cli.py
+++ b/esss_fix_format/cli.py
@@ -59,7 +59,7 @@ PATTERNS = {
 def should_format(filename):
     """Return True if the filename is of a type that is supported by this tool."""
     from fnmatch import fnmatch
-    return any(fnmatch(filename, p) for p in PATTERNS)
+    return any(fnmatch(os.path.split(filename)[-1], p) for p in PATTERNS)
 
 
 @click.command()

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ test_requirements = [
 
 setup(
     name='esss_fix_format',
-    version='1.4.0',
+    version='1.4.1',
     description="ESSS code formatter and checker",
     long_description=readme + '\n\n' + changelog,
     author="Bruno Oliveira",

--- a/tests/test_esss_fix_format.py
+++ b/tests/test_esss_fix_format.py
@@ -146,6 +146,13 @@ def test_unknown_extension(input_file):
     output.fnmatch_lines(str(new_filename) + ': Unknown file type')
 
 
+def test_filename_without_wildcard(tmpdir):
+    filename = tmpdir.join('CMakeLists.txt')
+    filename.write('\t#\n')
+    output = run([str(filename)], expected_exit=0)
+    output.fnmatch_lines(str(filename) + ': Fixed')
+
+
 @pytest.mark.parametrize('param', ['-c', '--commit'])
 def test_fix_commit(input_file, mocker, param, tmpdir):
 


### PR DESCRIPTION
… in subdirectories