### PR TITLE
Add known third party/standard library modules

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>esss_fix_format</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.python.pydev.PyDevBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.python.pydev.pythonNature</nature>
+	</natures>
+</projectDescription>

--- a/.pydevproject
+++ b/.pydevproject
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?eclipse-pydev version="1.0"?><pydev_project>
+<pydev_pathproperty name="org.python.pydev.PROJECT_SOURCE_PATH">
+<path>/${PROJECT_DIR_NAME}</path>
+</pydev_pathproperty>
+<pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python interpreter</pydev_property>
+<pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">Default</pydev_property>
+</pydev_project>

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,3 @@
+eclipse.preferences.version=1
+encoding//esss_fix_format/cli.py=utf-8
+encoding//tests/test_esss_fix_format.py=utf-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: python
 python: 3.5
 
 env:
-  - TOXENV=py36
   - TOXENV=py35
   - TOXENV=py27
   - TOXENV=linting

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,9 @@ language: python
 python: 3.5
 
 env:
+  - TOXENV=py36
   - TOXENV=py35
-  - TOXENV=py34
-  - TOXENV=py33
   - TOXENV=py27
-  - TOXENV=pypy
   - TOXENV=linting
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -101,7 +101,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, 3.3, 3.4 and 3.5, and for PyPy. Check
+3. The pull request should work for Python 2.7 and 3.5. Check
    https://travis-ci.org/esss/esss_fix_format/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/esss_fix_format/cli.py
+++ b/esss_fix_format/cli.py
@@ -13,7 +13,7 @@ all_stdlib_modules = ["Bastion", "CGIHTTPServer", "DocXMLRPCServer", "HTMLParser
                       "SimpleHTTPServer", "UserDict", "UserList", "UserString", "aifc",
                       "antigravity", "ast",
                       "audiodev", "bdb", "binhex", "cgi", "chunk", "code", "codeop", "colorsys",
-                      "cookielib", "copy_reg",
+                      "cookielib", "copy_reg", "email",
                       "dummy_thread", "dummy_threading", "formatter", "fpformat", "ftplib",
                       "genericpath",
                       "htmlentitydefs", "htmllib", "httplib", "ihooks", "imghdr", "imputil",
@@ -37,6 +37,7 @@ ISORT_CONFIG = {
     'use_parentheses': True,
     # This is a workaround for https://github.com/timothycrosley/isort/issues/464
     'known_standard_library': all_stdlib_modules,
+    'known_third_party': ["six", "six.moves"],
 }
 
 PATTERNS = {

--- a/esss_fix_format/cli.py
+++ b/esss_fix_format/cli.py
@@ -37,7 +37,7 @@ ISORT_CONFIG = {
     'use_parentheses': True,
     # This is a workaround for https://github.com/timothycrosley/isort/issues/464
     'known_standard_library': all_stdlib_modules,
-    'known_third_party': ["six", "six.moves"],
+    'known_third_party': ["six", "six.moves", "sip"],
 }
 
 PATTERNS = {

--- a/tests/test_esss_fix_format.py
+++ b/tests/test_esss_fix_format.py
@@ -208,7 +208,6 @@ def test_skip_entire_file(tmpdir):
     assert filename.read() == source
 
 
-@pytest.mark.xfail(reason='isort 4.2.5 bug, see timothycrosley/isort#460', strict=True)
 def test_isort_bug_with_comment_headers(tmpdir):
     source = textwrap.dedent("""\
         '''

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, linting
+envlist = py27, py35, linting
 
 [testenv:linting]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, linting
+envlist = py27, py35, py36, linting
 
 [testenv:linting]
 deps=


### PR DESCRIPTION
Workaround for issues in isort when dealing with email and six.moves (https://github.com/timothycrosley/isort/issues/596).