### PR TITLE
Fb fix isort skipped files

### DIFF
--- a/esss_fix_format/cli.py
+++ b/esss_fix_format/cli.py
@@ -96,11 +96,12 @@ def main(files_or_directories, check, stdin, commit):
                 errors.append(error_msg)
 
             sorter = isort.SortImports(file_contents=new_contents, settings_path=settings_path)
-            # strangely, if the entire file is skipped by an "isort:skip_file"
-            # instruction in the docstring, SortImports doesn't even contain an
-            # "output" attribute
-            if hasattr(sorter, 'output'):
-                new_contents = sorter.output
+            # On older versions if the entire file is skipped (eg.: by an "isort:skip_file")
+            # instruction in the docstring, SortImports doesn't even contain an "output" attribute.
+            # In some recent versions it is `None`.
+            new_contents = getattr(sorter, 'output', None)
+            if new_contents is None:
+                new_contents = original_contents
 
         new_contents = fix_whitespace(new_contents.splitlines(True), eol, ends_with_eol)
         changed = new_contents != original_contents

--- a/tests/test_esss_fix_format.py
+++ b/tests/test_esss_fix_format.py
@@ -202,14 +202,20 @@ def test_empty_file(tmpdir, sort_cfg_to_tmpdir):
     run([str(filename)], expected_exit=0)
 
 
-def test_skip_entire_file(tmpdir, sort_cfg_to_tmpdir):
-    """Check that a module-level isort:skip_file correctly skips that file"""
-    source = textwrap.dedent('''\
-        """
-        isort:skip_file
-        """
-        import sys
-    ''')
+@pytest.mark.parametrize(
+    'source',
+    [
+        '',
+        '"""\nisort:skip_file\n"""\nimport sys\nimport os\n',
+        '# isort:skip_file\nimport sys\nimport os\n',
+    ],
+    ids=[
+        'empty file',
+        'module-level isort:skip_file docstring',
+        'module-level isort:skip_file comment',
+    ]
+)
+def test_skip_entire_file(tmpdir, sort_cfg_to_tmpdir, source):
     filename = tmpdir.join('test.py')
     filename.write(source)
     output = run([str(filename)], expected_exit=0)


### PR DESCRIPTION
This fixes #19 
The master build is pretty old. I can't check the date but running master in my fork caused `test_skip_entire_file` to fail (I guess a new version of isort caused this failure).

Updated the test to cover more situations isort will skip the file (setting `sorter.output` to `None`).