### PR TITLE
Added check for non-ascii .cpp files

### DIFF
--- a/esss_fix_format/cli.py
+++ b/esss_fix_format/cli.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
+import codecs
 import io
 import os
+import re
 import subprocess
 import sys
 
@@ -156,6 +158,19 @@ def _process_file(filename, check, format_code):
     if not should_format(filename):
         click.secho(click.format_filename(filename) + ': Unknown file type', fg='white')
         return changed, errors, formatter
+
+    if is_cpp(filename):
+        with io.open(filename, 'rb') as f:
+            content_bytes = f.read()
+            content = content_bytes.decode()
+            non_ascii = re.sub('[ -~]', '', content).strip()
+            use_bom = non_ascii is not ''
+            if use_bom and not content_bytes.startswith(codecs.BOM_UTF8):
+                msg = ': ERROR Not a valid UTF-8 encoded file, since it contains non-ASCII characters. Ensure it has UTF-8 encoding with BOM.'
+                error_msg = click.format_filename(filename) + msg
+                click.secho(error_msg, fg='red')
+                errors.append(error_msg)
+                return changed, errors, formatter
 
     if is_cpp(filename) and should_use_clang_format(filename):
         formatter = 'clang-format'

--- a/esss_fix_format/cli.py
+++ b/esss_fix_format/cli.py
@@ -162,7 +162,10 @@ def _process_file(filename, check, format_code):
     if is_cpp(filename):
         with io.open(filename, 'rb') as f:
             content_bytes = f.read()
-            content = content_bytes.decode()
+            content = content_bytes.decode('UTF-8')
+            # Remove all ASCII-characters, by substituting all printable ASCII-characters
+            # with NULL character. Here, ' ' is the first printable ASCII-character (code 32)
+            # and '~' is the last printable ASCII-character (code 126).
             non_ascii = re.sub('[ -~]', '', content).strip()
             use_bom = len(non_ascii) > 0
             if use_bom and not content_bytes.startswith(codecs.BOM_UTF8):

--- a/esss_fix_format/cli.py
+++ b/esss_fix_format/cli.py
@@ -164,9 +164,12 @@ def _process_file(filename, check, format_code):
             content_bytes = f.read()
             content = content_bytes.decode()
             non_ascii = re.sub('[ -~]', '', content).strip()
-            use_bom = non_ascii is not ''
+            use_bom = len(non_ascii) > 0
             if use_bom and not content_bytes.startswith(codecs.BOM_UTF8):
-                msg = ': ERROR Not a valid UTF-8 encoded file, since it contains non-ASCII characters. Ensure it has UTF-8 encoding with BOM.'
+                msg = (
+                    ': ERROR Not a valid UTF-8 encoded file, since it contains'
+                    ' non-ASCII characters. Ensure it has UTF-8 encoding with BOM.'
+                )
                 error_msg = click.format_filename(filename) + msg
                 click.secho(error_msg, fg='red')
                 errors.append(error_msg)

--- a/tests/test_esss_fix_format.py
+++ b/tests/test_esss_fix_format.py
@@ -362,6 +362,35 @@ def test_install_pre_commit_hook_command_line(tmpdir):
     assert tmpdir.join('.git', 'hooks', '_pre-commit-parts').exists()
 
 
+def test_missing_bom_error_for_non_ascii_cpp(tmpdir):
+    '''
+    Throws an error for not encoding with "UTF-8 with BOM" of non-ascii cpp file.
+    '''
+    source = 'int     ŢōŶ;   '
+    filename = tmpdir.join('a.cpp')
+    filename.write(source)
+    output = run([str(filename)], expected_exit=1)
+    output.fnmatch_lines(
+        str(filename) + ': ERROR Not a valid UTF-8 encoded file, since it contains non-ASCII characters*')
+    output.fnmatch_lines('*== ERRORS ==*')
+    output.fnmatch_lines(
+        str(filename) + ': ERROR Not a valid UTF-8 encoded file, since it contains non-ASCII characters*')
+
+
+def test_bom_encoded_for_non_ascii_cpp(tmpdir, dot_clang_format_to_tmpdir):
+    '''
+    Formats non-ascii cpp as usual, if it has 'UTF-8 encoding with BOM'
+    '''
+    source = u'int     ŢōŶ;   '
+    filename = tmpdir.join('a.cpp')
+    filename.write_text(source, encoding='utf-8-sig')
+    check_invalid_file(filename, formatter='clang-format')
+    fix_invalid_file(filename, formatter='clang-format')
+    check_valid_file(filename, formatter='clang-format')
+    obtained = filename.read_text('utf-8-sig')
+    assert obtained == u'int ŢōŶ;'
+
+
 def test_use_legacy_formatter_when_there_is_no_dot_clang_format_for_valid(tmpdir):
     '''
     Won't format C++ if there's no `.clang-format` file in the directory or any directory above.

--- a/tests/test_esss_fix_format.py
+++ b/tests/test_esss_fix_format.py
@@ -366,9 +366,9 @@ def test_missing_bom_error_for_non_ascii_cpp(tmpdir):
     '''
     Throws an error for not encoding with "UTF-8 with BOM" of non-ascii cpp file.
     '''
-    source = 'int     ŢōŶ;   '
+    source = u'int     ŢōŶ;   '
     filename = tmpdir.join('a.cpp')
-    filename.write(source)
+    filename.write_text(source, encoding='UTF-8')
     output = run([str(filename)], expected_exit=1)
     output.fnmatch_lines(
         str(filename) + ': ERROR Not a valid UTF-8 encoded file, since it contains non-ASCII*')

--- a/tests/test_esss_fix_format.py
+++ b/tests/test_esss_fix_format.py
@@ -371,10 +371,10 @@ def test_missing_bom_error_for_non_ascii_cpp(tmpdir):
     filename.write(source)
     output = run([str(filename)], expected_exit=1)
     output.fnmatch_lines(
-        str(filename) + ': ERROR Not a valid UTF-8 encoded file, since it contains non-ASCII characters*')
+        str(filename) + ': ERROR Not a valid UTF-8 encoded file, since it contains non-ASCII*')
     output.fnmatch_lines('*== ERRORS ==*')
     output.fnmatch_lines(
-        str(filename) + ': ERROR Not a valid UTF-8 encoded file, since it contains non-ASCII characters*')
+        str(filename) + ': ERROR Not a valid UTF-8 encoded file, since it contains non-ASCII*')
 
 
 def test_bom_encoded_for_non_ascii_cpp(tmpdir, dot_clang_format_to_tmpdir):
@@ -383,11 +383,11 @@ def test_bom_encoded_for_non_ascii_cpp(tmpdir, dot_clang_format_to_tmpdir):
     '''
     source = u'int     ŢōŶ;   '
     filename = tmpdir.join('a.cpp')
-    filename.write_text(source, encoding='utf-8-sig')
+    filename.write_text(source, encoding='UTF-8-SIG')
     check_invalid_file(filename, formatter='clang-format')
     fix_invalid_file(filename, formatter='clang-format')
     check_valid_file(filename, formatter='clang-format')
-    obtained = filename.read_text('utf-8-sig')
+    obtained = filename.read_text('UTF-8-SIG')
     assert obtained == u'int ŢōŶ;'
 
 


### PR DESCRIPTION
Fixes issue #31 
Added a error message to throw in case the given .cpp file contains non-ascii characters, however doesn't have BOM at the beginning.