### PR TITLE
Add IndentPPDirectives

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -35,5 +35,6 @@ PenaltyBreakBeforeFirstCallParameter: 1
 PenaltyReturnTypeOnItsOwnLine: 200
 SpaceAfterCStyleCast: 'true'
 SpacesBeforeTrailingComments: '2'
+IndentPPDirectives: AfterHash
 
 ...


### PR DESCRIPTION
Edit the indenting style of our current format.
With this option enabled, the preprocessor directive will have indentation after the hash.

Before:
```cpp
#ifdef _WIN32
#include <optional>
#else
// This is needed since our libgcc is old
#include <experimental/optional>
namespace std {
using namespace std::experimental;
}
#endif
```

After:
```cpp
#ifdef _WIN32
#    include <optional>
#else
// This is needed since our libgcc is old
#    include <experimental/optional>
namespace std {
using namespace std::experimental;
}
#endif
```