### PR TITLE
Allow exclude files and directories from formatting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+2.1.0
+------------------
+
+* ``fix-format`` now allows exclude patterns to be configured through ``pyproject.toml``.
+
 2.0.1 (2019-06-26)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -53,17 +53,37 @@ Use ``fix-format`` (or ``ff`` for short) to reorder imports and format source co
 
 .. _black:
 
+Options
+-------
+
+Options for ``fix-format`` are defined in the section ``[tool.esss_fix_format]]`` of a ``pyproject.toml`` file. The
+TOML file should be placed in an ancestor directory of the filenames passed on the command-line.
+
+
+Exclude
+^^^^^^^
+
+A list of file name patterns to be excluded from the formatting. Patterns are matched using python ``fnmatch``:
+
+   .. code-block:: toml
+
+    [tool.esss_fix_format]
+    exclude = [
+        "src/generated/*.py",
+        "tmp/*",
+    ]
+
+
 Black
 ^^^^^
 
 Since version ``2.0.0`` it is possible to use `black <https://github.com/python/black>`__ as the
 code formatter for Python code.
 
-``fix-format`` will use ``black`` automatically if it finds a ``pyproject.toml`` with a ``[tool.black]`` section in an
-ancestor directories of the filenames passed on the command-line.
+``fix-format`` will use ``black`` automatically if it finds a ``[tool.black]`` section declared in ``pyproject.toml``
+file.
 
 See "Converting master to black" below for details.
-
 
 Migrating a project to use fix-format
 -------------------------------------

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -9,6 +9,7 @@ dependencies:
   - isort>=4.3.4
   - python={{ '.'.join(CONDA_PY) }}
   - pydevf==0.1.5
+  - toml>=0.8.0
 
   # develop
   - black

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ requirements = [
     'click>=6.0',
     'isort',
     'pydevf==0.1.5',
+    'toml>=0.8.0',
 ]
 
 setup(

--- a/src/esss_fix_format/cli.py
+++ b/src/esss_fix_format/cli.py
@@ -43,18 +43,18 @@ def is_cpp(filename):
     return any(fnmatch(os.path.basename(filename), p) for p in CPP_PATTERNS)
 
 
-def should_format(filename: str, include_patterns: Iterable[str], exclude_patterns: Iterable[str]) \
-        -> Tuple[bool, str]:
+def should_format(filename: str, include_patterns: Iterable[str], exclude_patterns: Iterable[str]):
     """
     Return a tuple (fmt, reason) where fmt is True if the filename should be formatted.
 
     :param filename: file name to verify if should be formatted or not
 
-    :param include_patterns: list of file patterns to be excluded from formatting
+    :param include_patterns: list of file patterns to be included in the formatting
 
-    :param exclude_patterns: list of file patterns to be excluded from formatting
+    :param exclude_patterns: list of file patterns to be excluded from formatting. Has precedence
+        over `include_patterns`
 
-    :rtype: bool
+    :rtype: Tuple[bool, str]
     """
     from fnmatch import fnmatch
 
@@ -114,7 +114,7 @@ def read_exclude_patterns(pyproject_toml: Path) -> List[str]:
     return excludes_option
 
 
-def has_black_config(pyproject_toml: Path) -> bool:
+def has_black_config(pyproject_toml: Optional[Path]) -> bool:
     if pyproject_toml is None:
         return False
     return pyproject_toml.is_file() and '[tool.black]' in pyproject_toml.read_text(encoding='UTF-8')

--- a/src/esss_fix_format/cli.py
+++ b/src/esss_fix_format/cli.py
@@ -38,6 +38,7 @@ SKIP_DIRS = {
 
 EXCLUDE_PATTERNS = []
 
+
 def is_cpp(filename):
     """Return True if the filename is of a type that should be treated as C++ source."""
     from fnmatch import fnmatch
@@ -96,6 +97,11 @@ def read_exclude_patterns(pyproject_toml: Path) -> List[str]:
     excludes_option = ff_options.get('exclude', [])
     if not isinstance(excludes_option, list):
         raise TypeError(f"pyproject.toml excludes option must be a list, got {type(excludes_option)})")
+
+    # Fix exclude paths based on cwd (exclude paths are defined relative to TOML file)
+    cwd_relpath_from_toml = os.path.relpath(os.getcwd(), pyproject_toml.parent)
+    if cwd_relpath_from_toml != '.':
+        excludes_option = [pattern.replace(cwd_relpath_from_toml + '/', '', 1) for pattern in excludes_option]
     return excludes_option
 
 

--- a/tests/test_esss_fix_format.py
+++ b/tests/test_esss_fix_format.py
@@ -756,7 +756,7 @@ def test_exclude_patterns(tmp_path, monkeypatch):
     assert cli.should_format('src/python/foo.py')[0]
 
 
-def test_invaldi_exclude_patterns(tmp_path):
+def test_invalid_exclude_patterns(tmp_path):
     config_content = '''[tool.esss_fix_format]
     exclude = "src/drafts/*.py"
     '''
@@ -764,3 +764,20 @@ def test_invaldi_exclude_patterns(tmp_path):
     config_file = tmp_path / 'pyproject.toml'
     config_file.write_text(config_content)
     pytest.raises(TypeError, cli.read_exclude_patterns, config_file)
+
+
+def test_exclude_patterns_relative_path_fix(tmp_path, monkeypatch):
+    config_content = '''[tool.esss_fix_format]
+    exclude = [
+        "src/drafts/*.py",
+        "tmp/*",
+    ]
+    '''
+
+    config_file = tmp_path / 'pyproject.toml'
+    run_dir = tmp_path / 'src'
+    run_dir.mkdir()
+    config_file.write_text(config_content)
+    monkeypatch.chdir(run_dir)
+    monkeypatch.setattr(cli, "EXCLUDE_PATTERNS", cli.read_exclude_patterns(config_file))
+    assert not cli.should_format('drafts/foo.py')[0]

--- a/tests/test_esss_fix_format.py
+++ b/tests/test_esss_fix_format.py
@@ -749,11 +749,12 @@ def test_exclude_patterns(tmp_path, monkeypatch):
 
     config_file = tmp_path / 'pyproject.toml'
     config_file.write_text(config_content)
-    monkeypatch.setattr(cli, "EXCLUDE_PATTERNS", cli.read_exclude_patterns(config_file))
-    assert not cli.should_format('src/drafts/foo.py')[0]
-    assert cli.should_format('src/drafts/foo.cpp')[0]
-    assert not cli.should_format('tmp/foo.cpp')[0]
-    assert cli.should_format('src/python/foo.py')[0]
+    include_patterns = ['*.cpp', '*.py']
+    exclude_patterns = cli.read_exclude_patterns(config_file)
+    assert not cli.should_format('src/drafts/foo.py', include_patterns, exclude_patterns)[0]
+    assert cli.should_format('src/drafts/foo.cpp', include_patterns, exclude_patterns)[0]
+    assert not cli.should_format('tmp/foo.cpp', include_patterns, exclude_patterns)[0]
+    assert cli.should_format('src/python/foo.py', include_patterns, exclude_patterns)[0]
 
 
 def test_invalid_exclude_patterns(tmp_path):
@@ -779,5 +780,6 @@ def test_exclude_patterns_relative_path_fix(tmp_path, monkeypatch):
     run_dir.mkdir()
     config_file.write_text(config_content)
     monkeypatch.chdir(run_dir)
-    monkeypatch.setattr(cli, "EXCLUDE_PATTERNS", cli.read_exclude_patterns(config_file))
-    assert not cli.should_format('drafts/foo.py')[0]
+    include_patterns = ['*.py']
+    exclude_patterns = cli.read_exclude_patterns(config_file)
+    assert not cli.should_format('drafts/foo.py', include_patterns, exclude_patterns)[0]


### PR DESCRIPTION
Make fix-format read a list of file exclude patterns from
[tool.esss_fix_format] section of a pyproject.toml file.

Fix #44