### PR TITLE
Error when running ff from a 'subst' Windows drive

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+2.1.2 (2019-08-26)
+------------------
+
+* Fix error when running on a Windows mounted drive.
+
 2.1.1 (2019-08-23)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
 
 setup(
     name='esss_fix_format',
-    version='2.1.0',
+    version='2.1.2',
     description="ESSS code formatter and checker",
     long_description=readme + '\n\n' + changelog,
     author="ESSS",

--- a/src/esss_fix_format/cli.py
+++ b/src/esss_fix_format/cli.py
@@ -107,10 +107,10 @@ def read_exclude_patterns(pyproject_toml: Path) -> List[str]:
             f"pyproject.toml excludes option must be a list, got {type(excludes_option)})"
         )
 
-    def ensure_abs(p):
+    def ensure_abspath(p):
         return os.path.join(pyproject_toml.parent, p) if not os.path.isabs(p) else p
 
-    excludes_option = [ensure_abs(p) for p in excludes_option]
+    excludes_option = [ensure_abspath(p) for p in excludes_option]
     return excludes_option
 
 

--- a/src/esss_fix_format/cli.py
+++ b/src/esss_fix_format/cli.py
@@ -58,7 +58,7 @@ def should_format(filename: str, include_patterns: Iterable[str], exclude_patter
     """
     from fnmatch import fnmatch
 
-    if any(fnmatch(filename, pattern) for pattern in exclude_patterns):
+    if any(fnmatch(os.path.abspath(filename), pattern) for pattern in exclude_patterns):
         return False, 'Excluded file'
 
     filename_no_ext, ext = os.path.splitext(filename)
@@ -88,7 +88,7 @@ def find_pyproject_toml(files_or_directories) -> Optional[Path]:
     """
     if not files_or_directories:
         return None
-    common = Path(os.path.commonpath(files_or_directories)).resolve()
+    common = Path(os.path.commonpath(files_or_directories)).absolute()
     for p in ([common] + list(common.parents)):
         fn = p / 'pyproject.toml'
         if fn.is_file():
@@ -107,10 +107,10 @@ def read_exclude_patterns(pyproject_toml: Path) -> List[str]:
             f"pyproject.toml excludes option must be a list, got {type(excludes_option)})"
         )
 
-    # Fix exclude paths based on cwd (exclude paths are defined relative to TOML file)
-    cwd_relpath_from_toml = os.path.relpath(os.getcwd(), pyproject_toml.parent)
-    if cwd_relpath_from_toml != '.':
-        excludes_option = [p.replace(cwd_relpath_from_toml + '/', '', 1) for p in excludes_option]
+    def ensure_abs(p):
+        return os.path.join(pyproject_toml.parent, p) if not os.path.isabs(p) else p
+
+    excludes_option = [ensure_abs(p) for p in excludes_option]
     return excludes_option
 
 


### PR DESCRIPTION
find_pyproject_toml was using Pathlib resolve() function, which resolve
'substed' drives on Windows. This was leading to errors on processing
exclude patterns since the TOML path had a drive different than the
current working dir.

find_pyproject_toml changed to use absolute() instead of resolve().
read_exclude_patterns was also refactored to return absolute paths
instead of relative ones, to increase robustness.

Fix #48