### PR TITLE
Pass all files to black at once on Linux

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,12 @@
 History
 =======
 
-3.1.1 (upcoming)
-------------------
+3.2.0 (upcoming)
+----------------
 
 * Add support to .cu (CUDA) files.
+* When running ``black`` on a large number of files, pass all files at once on Linux. Previously ``esss_fix_format`` would
+  pass files in chunks due to a limitation in Windows command-line size, but now that workaround is done in Windows only.
 
 3.1.0 (2020-12-18)
 ------------------


### PR DESCRIPTION
We used to pass files to black in chunks of 100 files at once, because of a Windows limitation regarding the maximum command-line size.

Limit this workaround to Windows only, speeding up running black on a large number of files on Linux.