### PR TITLE
Use `clang-format` dependency instead of `clangdev`

### DIFF
--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -5,7 +5,7 @@ name: esss-fix-format-py{{ PY }}
 dependencies:
   # run
   - boltons
-  - clangdev>=6.0.1
+  - clang-format
   - click>=6.0
   - isort>=5.0
   - python=3.{{ CONDA_PY[1:] }}


### PR DESCRIPTION
It's isolated and won't bring the ton of deps that `clangdev` brings